### PR TITLE
Proposal: implementation of struct: option for defmock

### DIFF
--- a/test/mox_test.exs
+++ b/test/mox_test.exs
@@ -99,6 +99,42 @@ defmodule MoxTest do
       end
     end
 
+    test "can clone structs" do
+      assert %{ans: 0} = %MyStructMock1{}
+      assert %{ans: 0} = %MyStructMock2{}
+    end
+
+    test "cloned struct must be from a valid module" do
+      expected_error = "the :struct option must be a module"
+
+      assert_raise ArgumentError, expected_error, fn ->
+        defmock(MyMock, for: Calculator, struct: "foo")
+      end
+
+      assert_raise ArgumentError, expected_error, fn ->
+        defmock(MyMock, for: Calculator, struct: NotAModule)
+      end
+    end
+
+    test "cloned struct must have an associated struct" do
+      Code.ensure_loaded(CalculatorNoStruct)
+      expected_error = "the :struct module must define a struct."
+
+      assert_raise ArgumentError, expected_error, fn ->
+        defmock(MyMock, for: Calculator, struct: CalculatorNoStruct)
+      end
+    end
+
+    test "struct source module must implement all behaviours" do
+      Code.ensure_loaded(CalculatorStructOneBehaviour)
+      expected_error = "the :struct module must implement all behaviours: Elixir.ScientificCalculator was not implemented."
+
+      assert_raise ArgumentError, expected_error, fn ->
+        defmock(MyMock, for: [Calculator, ScientificCalculator],
+          struct: CalculatorStructOneBehaviour)
+      end
+    end
+
     @tag :requires_code_fetch_docs
     test "uses false for when moduledoc is not given" do
       assert {:docs_v1, _, :elixir, "text/markdown", :hidden, _, _} =

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -4,3 +4,6 @@ Mox.defmock(SciCalcMock, for: [Calculator, ScientificCalculator])
 Mox.defmock(MyMockWithoutModuledoc, for: Calculator)
 Mox.defmock(MyMockWithFalseModuledoc, for: Calculator, moduledoc: false)
 Mox.defmock(MyMockWithStringModuledoc, for: Calculator, moduledoc: "hello world")
+
+Mox.defmock(MyStructMock1, for: [Calculator], struct: CalculatorWithStruct)
+Mox.defmock(MyStructMock2, for: [Calculator, ScientificCalculator], struct: CalculatorWithStruct)

--- a/test/support/structs.ex
+++ b/test/support/structs.ex
@@ -1,0 +1,22 @@
+defmodule CalculatorWithStruct do
+  @behaviour Calculator
+  @behaviour ScientificCalculator
+  def add(a, b), do: a + b
+  def mult(a, b), do: a * b
+  def exponent(a, b), do: a - b
+  def sin(a), do: a * 1.0
+  defstruct [ans: 0]
+end
+
+defmodule CalculatorStructOneBehaviour do
+  @behaviour Calculator
+  def add(a, b), do: a + b
+  def mult(a, b), do: a * b
+  defstruct [ans: 0]
+end
+
+defmodule CalculatorNoStruct do
+  @behaviour Calculator
+  def add(a, b), do: a + b
+  def mult(a, b), do: a * b
+end


### PR DESCRIPTION
In some cases I have found myself wanting to be able to clone a struct from an implementation module to build a mock.  This PR creates a `:struct` option for defmock, which drags the source module's struct into the mock implementation.  Before cloning, the struct-bearing module is checked to see if it matches the behaviours in the mock module.  Hopefully this fits in the spirit of mocks being nouns, not verbs, and doesn't interfere too much with the nominal operation of mox!