### PR TITLE
docs: Fix docs on auto setting mode from context

### DIFF
--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -162,8 +162,9 @@ defmodule Mox do
 
   Mox supports global mode, where any process can consume mocks and stubs
   defined in your tests. `set_mox_from_context/0` automatically calls
-  `set_mox_private/1` if the test context includes `async: true`.
-  
+  `set_mox_global/1` but only if the test context **doesn't** include
+  `async: true`.
+
   By default the mode is `:private`.
 
       setup :set_mox_from_context

--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -162,7 +162,9 @@ defmodule Mox do
 
   Mox supports global mode, where any process can consume mocks and stubs
   defined in your tests. `set_mox_from_context/0` automatically calls
-  `set_mox_global/1` if the test context includes `async: true`.
+  `set_mox_private/1` if the test context includes `async: true`.
+  
+  By default the mode is `:private`.
 
       setup :set_mox_from_context
       setup :verify_on_exit!


### PR DESCRIPTION
The docs said that `set_mox_from_context` would call `set_global_mode` if the test context includes `async: true` but it's actually the other way around.

Having `async: true` leads to `set_private_mode` being called.

I've also added a bit on which mode is default (`:private`).