### PR TITLE
use ~S to prevent interpolation

### DIFF
--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -1,5 +1,5 @@
 defmodule Mox do
-  @moduledoc """
+  @moduledoc ~S"""
   Mox is a library for defining concurrent mocks in Elixir.
 
   The library follows the principles outlined in


### PR DESCRIPTION
Went with ~S over escaping the `#` char so that plain-text still remains readable and copy-pastable.