### PR TITLE
Add basic usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Mox should be automatically started unless the `:applications` key is set inside
 
 ## Basic Usage
 
-### 1) Add behaviour, defining the contract:
+### 1) Add behaviour, defining the contract
+
 ```elixir
 # lib/weather_behaviour.ex
 defmodule WeatherBehaviour do
@@ -42,6 +43,7 @@ end
 ```
 
 ### 2) Add implementation for the behaviour
+
 ```elixir
 # lib/weather_impl.ex
 defmodule WeatherImpl do
@@ -69,7 +71,9 @@ end
 ```
 
 ### 3) Add a switch
+
 This can pull from your `config/config.exs`, `config/test.exs`, or, you can have no config as shown below and rely on a default. We also add a function to a higher level abstraction that will call the correct implementation:
+
 ```elixir
 # bound.ex, the main context we chose to call this function from
 defmodule Bound do
@@ -83,15 +87,18 @@ defmodule Bound do
 end
 ```
 
-### 4) Define the mock so it is used during tests:
+### 4) Define the mock so it is used during tests
+
 ```elixir
-# in test/test_helper.exs
+# In your test/test_helper.exs
 Mox.defmock(WeatherBehaviourMock, for: WeatherBehaviour) # <- Add this
 Application.put_env(:bound, :weather, WeatherBehaviourMock) # <- Add this
- ExUnit.start()
+
+ExUnit.start()
 ```
 
-### 5) Create a test and use `expect` so we can assert on the arguments that are passed to the mock.
+### 5) Create a test and use `expect` to assert on the mock arguments
+
 ```elixir
 # test/bound_test.exs
 defmodule BoundTest do


### PR DESCRIPTION
Hi @josevalim!

Two things I wanted to bring up. I combined them because I think the last one
is just tangentially related to the first one.

1) I was working with someone the other week and they mentioned the docs could
have used more of a step-by-step flow rather than the current flow.

The current docs work for me, but I like to try to listen to "first impression"
feedback when I do get it. I really listen when it is folks new to the
community. So, I thought that a good place to add the step by step version
would be on the README and we could keep the moduledocs as they are as they are
helpful as well.

The second point is below, related to where I added the docs (in the README)
and also somewhat tangential because I'm asking about preferences not only for
this library, but for libraries in general.

2) From what I've seen, there seems to some value in libraries that have
READMEs showcasing 20% of the library features that may be responsible for 80%
of the general usage. Saving that extra click to go to the docs/hex/guides is a win.

My experience may be completely anecdotal, that's why I'm reaching out as I
know you have written your fair share of READMEs in the past and may know
something I don't on this subject.

We have Hex to serve moduledocs and guides. Is that where you think libraries
should focus on their examples/usage? What are your thoughts on this "80/20"
README? Here is an [example of an 80/20 README in the
wild](https://github.com/michalmuskala/jason#basic-usage)

I'm interested in your thoughts. Happy to move this discussion elsewhere as
well. Feel free to ping me in ElixirForum, EEF Slack, anywhere.

As usual, feel free to discard the changes here if you want to, no hard
feelings! Thanks for your work! :heart: