### PR TITLE
Update mox.ex moduledoc on stub_with

### DIFF
--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -98,6 +98,7 @@ defmodule Mox do
 
         setup _ do
           Mox.stub_with(MyApp.MockWeatherAPI, MyApp.StubWeatherAPI)
+          :ok
         end
       end
 


### PR DESCRIPTION
The code example explaining usage of `stub_with/2` was not a  valid ExUnit.setup block because it would return an atom rather than `:ok | keyword | map`.
This PR alters the code example to return `:ok`.