### PR TITLE
Cluster testing

### DIFF
--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -802,6 +802,16 @@ defmodule Mox do
               "expected #{mfa} to be called #{times(count)} but it has been " <>
                 "called #{times(count + 1)} in #{format_process()}"
 
+      {:remote, fun_to_call} ->
+        # it's possible that Mox.Server is running on a remote node in the cluster.  Since the lambda
+        # that we passed is not guaranteed to exist on this node (it might have come from a .exs file)
+        # find the remote node that hosts Mox.Server, and run the lambda on that node.
+
+        Mox.Server
+        |> :global.whereis_name()
+        |> node
+        |> :rpc.call(Kernel, :apply, [fun_to_call, args])
+
       {:ok, fun_to_call} ->
         apply(fun_to_call, args)
     end

--- a/lib/mox/server.ex
+++ b/lib/mox/server.ex
@@ -260,5 +260,5 @@ defmodule Mox.Server do
   end
 
   defp ok_or_remote(source) when node(source) == node(), do: :ok
-  defp ok_or_remote(source), do: :remote
+  defp ok_or_remote(_source), do: :remote
 end

--- a/lib/mox/server.ex
+++ b/lib/mox/server.ex
@@ -3,35 +3,42 @@ defmodule Mox.Server do
 
   use GenServer
   @timeout 30000
+  @this {:global, __MODULE__}
 
   # API
 
   def start_link(_options) do
-    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+    case GenServer.start_link(__MODULE__, :ok, name: @this) do
+      {:error, {:already_started, _}} ->
+        :ignore
+
+      other ->
+        other
+    end
   end
 
   def add_expectation(owner_pid, key, value) do
-    GenServer.call(__MODULE__, {:add_expectation, owner_pid, key, value}, @timeout)
+    GenServer.call(@this, {:add_expectation, owner_pid, key, value}, @timeout)
   end
 
   def fetch_fun_to_dispatch(caller_pids, key) do
-    GenServer.call(__MODULE__, {:fetch_fun_to_dispatch, caller_pids, key}, @timeout)
+    GenServer.call(@this, {:fetch_fun_to_dispatch, caller_pids, key, self()}, @timeout)
   end
 
   def verify(owner_pid, for, test_or_on_exit) do
-    GenServer.call(__MODULE__, {:verify, owner_pid, for, test_or_on_exit}, @timeout)
+    GenServer.call(@this, {:verify, owner_pid, for, test_or_on_exit}, @timeout)
   end
 
   def verify_on_exit(pid) do
-    GenServer.call(__MODULE__, {:verify_on_exit, pid}, @timeout)
+    GenServer.call(@this, {:verify_on_exit, pid}, @timeout)
   end
 
   def allow(mock, owner_pid, pid) do
-    GenServer.call(__MODULE__, {:allow, mock, owner_pid, pid}, @timeout)
+    GenServer.call(@this, {:allow, mock, owner_pid, pid}, @timeout)
   end
 
   def set_mode(owner_pid, mode) do
-    GenServer.call(__MODULE__, {:set_mode, owner_pid, mode})
+    GenServer.call(@this, {:set_mode, owner_pid, mode})
   end
 
   # Callbacks
@@ -104,7 +111,7 @@ defmodule Mox.Server do
   end
 
   def handle_call(
-        {:fetch_fun_to_dispatch, caller_pids, {mock, _, _} = key},
+        {:fetch_fun_to_dispatch, caller_pids, {mock, _, _} = key, source},
         %{mode: :private} = state
       ) do
     owner_pid =
@@ -124,16 +131,16 @@ defmodule Mox.Server do
         {:reply, {:out_of_expectations, total}, state}
 
       {_, [], stub} ->
-        {:reply, {:ok, stub}, state}
+        {:reply, {ok_or_remote(source), stub}, state}
 
       {total, [call | calls], stub} ->
         new_state = put_in(state.expectations[owner_pid][key], {total, calls, stub})
-        {:reply, {:ok, call}, new_state}
+        {:reply, {ok_or_remote(source), call}, new_state}
     end
   end
 
   def handle_call(
-        {:fetch_fun_to_dispatch, _caller_pids, {_mock, _, _} = key},
+        {:fetch_fun_to_dispatch, _caller_pids, {_mock, _, _} = key, source},
         %{mode: :global} = state
       ) do
     case state.expectations[state.global_owner_pid][key] do
@@ -144,11 +151,11 @@ defmodule Mox.Server do
         {:reply, {:out_of_expectations, total}, state}
 
       {_, [], stub} ->
-        {:reply, {:ok, stub}, state}
+        {:reply, {ok_or_remote(source), stub}, state}
 
       {total, [call | calls], stub} ->
         new_state = put_in(state.expectations[state.global_owner_pid][key], {total, calls, stub})
-        {:reply, {:ok, call}, new_state}
+        {:reply, {ok_or_remote(source), call}, new_state}
     end
   end
 
@@ -251,4 +258,7 @@ defmodule Mox.Server do
   defp merge_expectation({current_n, current_calls, _current_stub}, {n, calls, stub}) do
     {current_n + n, current_calls ++ calls, stub}
   end
+
+  defp ok_or_remote(source) when node(source) == node(), do: :ok
+  defp ok_or_remote(source), do: :remote
 end

--- a/test/cluster_test.exs
+++ b/test/cluster_test.exs
@@ -1,0 +1,47 @@
+defmodule MoxTest.ClusterTest do
+  use ExUnit.Case, async: true
+  import Mox
+
+  setup_all do
+    Task.start_link(fn ->
+      System.cmd("epmd", [])
+    end)
+
+    Process.sleep(100)
+    {:ok, _} = :net_kernel.start([:primary, :shortnames])
+    :peer.start(%{name: :peer})
+    [peer] = Node.list()
+    :rpc.call(peer, :code, :add_paths, [:code.get_path()])
+    :rpc.call(peer, Application, :ensure_all_started, [:mix])
+    :rpc.call(peer, Application, :ensure_all_started, [:logger])
+    :rpc.call(peer, Logger, :configure, [[level: Logger.level()]])
+    :rpc.call(peer, Mix, :env, [Mix.env()])
+    :rpc.call(peer, Application, :ensure_all_started, [:mox])
+    :ok
+  end
+
+  test "an allowance can commute over the cluster" do
+    set_mox_private()
+
+    Mox.expect(CalcMock, :add, &Kernel.+/2)
+
+    quoted =
+      quote do
+        primary =
+          receive do
+            {:unblock, pid} -> pid
+          end
+
+        send(primary, {:result, CalcMock.add(1, 1)})
+      end
+
+    peer =
+      Node.list()
+      |> List.first()
+      |> Node.spawn(Code, :eval_quoted, [quoted])
+
+    Mox.allow(CalcMock, self(), peer)
+    send(peer, {:unblock, self()})
+    assert_receive {:result, 2}
+  end
+end

--- a/test/cluster_test.exs
+++ b/test/cluster_test.exs
@@ -1,5 +1,5 @@
 defmodule MoxTest.ClusterTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
   import Mox
 
   setup_all do
@@ -7,7 +7,6 @@ defmodule MoxTest.ClusterTest do
       System.cmd("epmd", [])
     end)
 
-    Process.sleep(100)
     {:ok, _} = :net_kernel.start([:primary, :shortnames])
     :peer.start(%{name: :peer})
     [peer] = Node.list()
@@ -16,14 +15,19 @@ defmodule MoxTest.ClusterTest do
     :rpc.call(peer, Application, :ensure_all_started, [:logger])
     :rpc.call(peer, Logger, :configure, [[level: Logger.level()]])
     :rpc.call(peer, Mix, :env, [Mix.env()])
+    # force the primary global Mox Server registration to be synced, otherwise
+    # there is a race condition, since global doesn't actively sync all the time.
+    # the sync event should happen BEFORE connecting mox, otherwise it is not
+    # deterministic which global mox server will survive.
+    :rpc.call(peer, :global, :sync, [])
     :rpc.call(peer, Application, :ensure_all_started, [:mox])
     :ok
   end
 
-  test "an allowance can commute over the cluster" do
+  test "an allowance can commute over the cluster in private mode" do
     set_mox_private()
 
-    Mox.expect(CalcMock, :add, &Kernel.+/2)
+    Mox.expect(CalcMock, :add, fn a, b -> a + b end)
 
     quoted =
       quote do
@@ -41,6 +45,30 @@ defmodule MoxTest.ClusterTest do
       |> Node.spawn(Code, :eval_quoted, [quoted])
 
     Mox.allow(CalcMock, self(), peer)
+    send(peer, {:unblock, self()})
+    assert_receive {:result, 2}
+  end
+
+  test "an allowance can commute over the cluster in global mode" do
+    set_mox_global()
+
+    Mox.expect(CalcMock, :add, fn a, b -> a + b end)
+
+    quoted =
+      quote do
+        primary =
+          receive do
+            {:unblock, pid} -> pid
+          end
+
+        send(primary, {:result, CalcMock.add(1, 1)})
+      end
+
+    peer =
+      Node.list()
+      |> List.first()
+      |> Node.spawn(Code, :eval_quoted, [quoted])
+
     send(peer, {:unblock, self()})
     assert_receive {:result, 2}
   end

--- a/test/cluster_test.exs
+++ b/test/cluster_test.exs
@@ -1,75 +1,84 @@
-defmodule MoxTest.ClusterTest do
-  use ExUnit.Case
-  import Mox
+# :peer module only available in otp release 25 or greater
 
-  setup_all do
-    Task.start_link(fn ->
-      System.cmd("epmd", [])
-    end)
+otp_release =
+  :otp_release
+  |> :erlang.system_info()
+  |> List.to_integer()
 
-    {:ok, _} = :net_kernel.start([:primary, :shortnames])
-    :peer.start(%{name: :peer})
-    [peer] = Node.list()
-    :rpc.call(peer, :code, :add_paths, [:code.get_path()])
-    :rpc.call(peer, Application, :ensure_all_started, [:mix])
-    :rpc.call(peer, Application, :ensure_all_started, [:logger])
-    :rpc.call(peer, Logger, :configure, [[level: Logger.level()]])
-    :rpc.call(peer, Mix, :env, [Mix.env()])
-    # force the primary global Mox Server registration to be synced, otherwise
-    # there is a race condition, since global doesn't actively sync all the time.
-    # the sync event should happen BEFORE connecting mox, otherwise it is not
-    # deterministic which global mox server will survive.
-    :rpc.call(peer, :global, :sync, [])
-    :rpc.call(peer, Application, :ensure_all_started, [:mox])
-    :ok
-  end
+if otp_release >= 25 do
+  defmodule MoxTest.ClusterTest do
+    use ExUnit.Case
+    import Mox
 
-  test "an allowance can commute over the cluster in private mode" do
-    set_mox_private()
+    setup_all do
+      Task.start_link(fn ->
+        System.cmd("epmd", [])
+      end)
 
-    Mox.expect(CalcMock, :add, fn a, b -> a + b end)
+      {:ok, _} = :net_kernel.start([:primary, :shortnames])
+      :peer.start(%{name: :peer})
+      [peer] = Node.list()
+      :rpc.call(peer, :code, :add_paths, [:code.get_path()])
+      :rpc.call(peer, Application, :ensure_all_started, [:mix])
+      :rpc.call(peer, Application, :ensure_all_started, [:logger])
+      :rpc.call(peer, Logger, :configure, [[level: Logger.level()]])
+      :rpc.call(peer, Mix, :env, [Mix.env()])
+      # force the primary global Mox Server registration to be synced, otherwise
+      # there is a race condition, since global doesn't actively sync all the time.
+      # the sync event should happen BEFORE connecting mox, otherwise it is not
+      # deterministic which global mox server will survive.
+      :rpc.call(peer, :global, :sync, [])
+      :rpc.call(peer, Application, :ensure_all_started, [:mox])
+      :ok
+    end
 
-    quoted =
-      quote do
-        primary =
-          receive do
-            {:unblock, pid} -> pid
-          end
+    test "an allowance can commute over the cluster in private mode" do
+      set_mox_private()
 
-        send(primary, {:result, CalcMock.add(1, 1)})
-      end
+      Mox.expect(CalcMock, :add, fn a, b -> a + b end)
 
-    peer =
-      Node.list()
-      |> List.first()
-      |> Node.spawn(Code, :eval_quoted, [quoted])
+      quoted =
+        quote do
+          primary =
+            receive do
+              {:unblock, pid} -> pid
+            end
 
-    Mox.allow(CalcMock, self(), peer)
-    send(peer, {:unblock, self()})
-    assert_receive {:result, 2}
-  end
+          send(primary, {:result, CalcMock.add(1, 1)})
+        end
 
-  test "an allowance can commute over the cluster in global mode" do
-    set_mox_global()
+      peer =
+        Node.list()
+        |> List.first()
+        |> Node.spawn(Code, :eval_quoted, [quoted])
 
-    Mox.expect(CalcMock, :add, fn a, b -> a + b end)
+      Mox.allow(CalcMock, self(), peer)
+      send(peer, {:unblock, self()})
+      assert_receive {:result, 2}
+    end
 
-    quoted =
-      quote do
-        primary =
-          receive do
-            {:unblock, pid} -> pid
-          end
+    test "an allowance can commute over the cluster in global mode" do
+      set_mox_global()
 
-        send(primary, {:result, CalcMock.add(1, 1)})
-      end
+      Mox.expect(CalcMock, :add, fn a, b -> a + b end)
 
-    peer =
-      Node.list()
-      |> List.first()
-      |> Node.spawn(Code, :eval_quoted, [quoted])
+      quoted =
+        quote do
+          primary =
+            receive do
+              {:unblock, pid} -> pid
+            end
 
-    send(peer, {:unblock, self()})
-    assert_receive {:result, 2}
+          send(primary, {:result, CalcMock.add(1, 1)})
+        end
+
+      peer =
+        Node.list()
+        |> List.first()
+        |> Node.spawn(Code, :eval_quoted, [quoted])
+
+      send(peer, {:unblock, self()})
+      assert_receive {:result, 2}
+    end
   end
 end


### PR DESCRIPTION
The current guidelines for best practices suggest shipping mocked module names in module attributes, which are compile-time values effectively hardcoded into the `.beam` file.  Thus there may be cases, (especially for integration tests) where a remote node might have to handle a request with no way of connecting back to the relevant mox expectations associated with the test.

This PR makes mox cluster aware, so another node connected in the cluster can access the same mox checkouts on the primary node.

Additional documentation has not been provided, happy to add documentation.  The one big warning is `:global` registry should be synced after connecting the node, but *before* ensuring Applications are running in the "peer" node, or else there may not be a deterministic selection of the `Mox.Server` process, killing the existing Server, and this could cause problems for other tests that are running, if the peer node is spun up at some point in the testing that isn't global (e.g. inside of a `setup_all` vs inside of `test_helper.exs`)