### PR TITLE
docs: Stop suggest calling `stub_with` at compilation time

### DIFF
--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -576,7 +576,11 @@ defmodule Mox do
       end
 
       defmock(MyApp.MockWeatherAPI, for: MyApp.WeatherAPI)
-      stub_with(MyApp.MockWeatherAPI, MyApp.StubWeatherAPI)
+
+      setup do
+        stub_with(MyApp.MockWeatherAPI, MyApp.StubWeatherAPI)
+        :ok
+      end
 
   This is the same as calling `stub/3` for each callback in `MyApp.MockWeatherAPI`:
 


### PR DESCRIPTION
The docs are still slightly suggesting that `stub_with` can be used just as `defmock` function in the `test_helper.exs` file, which is not true. https://github.com/dashbitco/mox/issues/122 was not enough to prevent devs from doing that mistake again.

Moreover, if a developer does it, the `stub_with` call in the test helper won't raise any error (even though it has no effect); only later on in the test files they will meet unhelpful errors like `no expectation defined for ...`, making the root cause hard to discover.

Let's help avoiding it.