### PR TITLE
Accept `(-> pid())` in `allow/3`

### DIFF
--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -187,10 +187,9 @@ defmodule Mox do
 
   Under some circumstances, the process might not have been already started
   when the allowance happens. In such a case, you might specify the allowance
-  as a lazy/deferred function call in a form `(-> pid())`. This function
-  would be resolved late, at the very moment of dispatch. Please note, that no
-  additional diagnostics could have been provided for lazy calls, and it would
-  either succeed, or fail with `Mox.UnexpectedCallError`. 
+  as a function in the form `(-> pid())`. This function would be resolved late,
+  at the very moment of dispatch. If the function does not return an existing
+  PID, it will fail `Mox.UnexpectedCallError`. 
 
   ### Global mode
 
@@ -680,9 +679,9 @@ defmodule Mox do
       allow(MyMock, self(), SomeChildProcess)
 
   If the process is not yet started at the moment of allowance definition,
-  it might be allowed as a lazy call, assuming at the moment of validation
+  it might be allowed as a function, assuming at the moment of invocation
   it would have been started. If the function cannot be resolved to a `pid`
-  during call dispatch, the expectation would not succeed.
+  during invocation, the expectation will not succeed.
 
       allow(MyMock, self(), fn -> GenServer.whereis(Deferred) end)
   """

--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -673,19 +673,23 @@ defmodule Mox do
   """
   @spec allow(mock, pid(), term()) :: mock when mock: t()
   def allow(mock, owner_pid, allowed_via) when is_atom(mock) and is_pid(owner_pid) do
-    allowed_pid = GenServer.whereis(allowed_via)
+    allowed_pid_or_promise =
+      case allowed_via do
+        {:promise, fun} when is_function(fun, 0) -> allowed_via
+        _ -> GenServer.whereis(allowed_via)
+      end
 
-    if allowed_pid == owner_pid do
+    if allowed_pid_or_promise == owner_pid do
       raise ArgumentError, "owner_pid and allowed_pid must be different"
     end
 
-    case Mox.Server.allow(mock, owner_pid, allowed_pid) do
+    case Mox.Server.allow(mock, owner_pid, allowed_pid_or_promise) do
       :ok ->
         mock
 
       {:error, {:already_allowed, actual_pid}} ->
         raise ArgumentError, """
-        cannot allow #{inspect(allowed_pid)} to use #{inspect(mock)} from #{inspect(owner_pid)} \
+        cannot allow #{inspect(allowed_pid_or_promise)} to use #{inspect(mock)} from #{inspect(owner_pid)} \
         because it is already allowed by #{inspect(actual_pid)}.
 
         If you are seeing this error message, it is because you are either \
@@ -696,7 +700,7 @@ defmodule Mox do
 
       {:error, :expectations_defined} ->
         raise ArgumentError, """
-        cannot allow #{inspect(allowed_pid)} to use #{inspect(mock)} from #{inspect(owner_pid)} \
+        cannot allow #{inspect(allowed_pid_or_promise)} to use #{inspect(mock)} from #{inspect(owner_pid)} \
         because the process has already defined its own expectations/stubs
         """
 

--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -183,6 +183,15 @@ defmodule Mox do
   `$callers` is used to determine the process that actually defined the
   expectations.
 
+  #### Explicit allowances as promises
+
+  Under some circumstances, the process might not have been already started
+  when the allowance happens. In such a case, you might specify the allowance
+  as a promise in a form `{:promise, (-> pid())}`. This promise would be
+  resolving late, at the very moment of dispatch. Please note, that no
+  additional diagnostics could have been provided for promises, and it would
+  either succeed, or fail with `Mox.UnexpectedCallError`. 
+
   ### Global mode
 
   Mox supports global mode, where any process can consume mocks and stubs
@@ -670,6 +679,12 @@ defmodule Mox do
 
       allow(MyMock, self(), SomeChildProcess)
 
+  If the process is not yet started at the moment of allowance definition,
+  it might be allowed as a promise, assuming at the moment of validation
+  it would have been started. If the function cannot be resolved to a `pid`
+  during call dispatch, the expectation would not succeed.
+
+      allow(MyMock, self(), {:promise, fn -> GenServer.whereis(Deferred) end})
   """
   @spec allow(mock, pid(), term()) :: mock when mock: t()
   def allow(mock, owner_pid, allowed_via) when is_atom(mock) and is_pid(owner_pid) do

--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -187,7 +187,7 @@ defmodule Mox do
 
   Under some circumstances, the process might not have been already started
   when the allowance happens. In such a case, you might specify the allowance
-  as a promise in a form `{:promise, (-> pid())}`. This promise would be
+  as a promise in a form `(-> pid())`. This promise would be
   resolving late, at the very moment of dispatch. Please note, that no
   additional diagnostics could have been provided for promises, and it would
   either succeed, or fail with `Mox.UnexpectedCallError`. 
@@ -684,14 +684,14 @@ defmodule Mox do
   it would have been started. If the function cannot be resolved to a `pid`
   during call dispatch, the expectation would not succeed.
 
-      allow(MyMock, self(), {:promise, fn -> GenServer.whereis(Deferred) end})
+      allow(MyMock, self(), fn -> GenServer.whereis(Deferred) end)
   """
   @spec allow(mock, pid(), term()) :: mock when mock: t()
   def allow(mock, owner_pid, allowed_via) when is_atom(mock) and is_pid(owner_pid) do
     allowed_pid_or_promise =
       case allowed_via do
-        {:promise, fun} when is_function(fun, 0) -> allowed_via
-        _ -> GenServer.whereis(allowed_via)
+        fun when is_function(fun, 0) -> fun
+        pid_or_name -> GenServer.whereis(pid_or_name)
       end
 
     if allowed_pid_or_promise == owner_pid do

--- a/test/mox_test.exs
+++ b/test/mox_test.exs
@@ -860,7 +860,7 @@ defmodule MoxTest do
 
       CalcMock
       |> expect(:add, fn _, _ -> :expected end)
-      |> allow(self(), {:promise, fn -> GenServer.whereis(name) end})
+      |> allow(self(), fn -> GenServer.whereis(name) end)
 
       {:ok, _} = GenServer.start_link(CalculatorServer_Promises, [], name: name)
       add_result = GenServer.call(name, :call_mock)

--- a/test/mox_test.exs
+++ b/test/mox_test.exs
@@ -62,7 +62,10 @@ defmodule MoxTest do
     end
 
     test "accepts false to indicate all functions should be generated" do
-      defmock(MyFalseMock, for: [Calculator, ScientificCalculator], skip_optional_callbacks: false)
+      defmock(MyFalseMock,
+        for: [Calculator, ScientificCalculator],
+        skip_optional_callbacks: false
+      )
 
       all_callbacks = ScientificCalculator.behaviour_info(:callbacks)
       assert all_callbacks -- MyFalseMock.__info__(:functions) == []
@@ -834,6 +837,32 @@ defmodule MoxTest do
       |> expect(:add, fn _, _ -> :expected end)
       |> allow(self(), name)
 
+      add_result = GenServer.call(name, :call_mock)
+      assert add_result == :expected
+    end
+
+    test "allowances support promises for processes registered through a Registry" do
+      defmodule CalculatorServer_Promises do
+        use GenServer
+
+        def init(args) do
+          {:ok, args}
+        end
+
+        def handle_call(:call_mock, _from, []) do
+          add_result = CalcMock.add(1, 1)
+          {:reply, add_result, []}
+        end
+      end
+
+      {:ok, _} = Registry.start_link(keys: :unique, name: Registry.Test)
+      name = {:via, Registry, {Registry.Test, :test_process_promise}}
+
+      CalcMock
+      |> expect(:add, fn _, _ -> :expected end)
+      |> allow(self(), {:promise, fn -> GenServer.whereis(name) end})
+
+      {:ok, _} = GenServer.start_link(CalculatorServer_Promises, [], name: name)
       add_result = GenServer.call(name, :call_mock)
       assert add_result == :expected
     end

--- a/test/mox_test.exs
+++ b/test/mox_test.exs
@@ -841,8 +841,8 @@ defmodule MoxTest do
       assert add_result == :expected
     end
 
-    test "allowances support promises for processes registered through a Registry" do
-      defmodule CalculatorServer_Promises do
+    test "allowances support lazy calls for processes registered through a Registry" do
+      defmodule CalculatorServer_Lazy do
         use GenServer
 
         def init(args) do
@@ -856,13 +856,13 @@ defmodule MoxTest do
       end
 
       {:ok, _} = Registry.start_link(keys: :unique, name: Registry.Test)
-      name = {:via, Registry, {Registry.Test, :test_process_promise}}
+      name = {:via, Registry, {Registry.Test, :test_process_lazy}}
 
       CalcMock
       |> expect(:add, fn _, _ -> :expected end)
       |> allow(self(), fn -> GenServer.whereis(name) end)
 
-      {:ok, _} = GenServer.start_link(CalculatorServer_Promises, [], name: name)
+      {:ok, _} = GenServer.start_link(CalculatorServer_Lazy, [], name: name)
       add_result = GenServer.call(name, :call_mock)
       assert add_result == :expected
     end


### PR DESCRIPTION
Sometimes, especially in less-unit and more-integration tests, the process to allow to use expectations in not yet started. In such a case, it would be great to have an ability for late-bound-allowances.

This PR provides an ad-hoc implementation of `{:promise, fn -> resolve_pid_lately() end)}` allowance, which does not have any implications until used, and attempts late binding right before dispatch. For instance, for named processes, it might look like `{:promise, fn -> GenServer.whereis(DeferredProcess) end}`.

This is not elegant, but it might be useful for many developers. Now I have to use global allowance with stubs for that.