### PR TITLE
Improve `verify/0` and `verify/1` test coverage

### DIFF
--- a/test/mox_test.exs
+++ b/test/mox_test.exs
@@ -411,23 +411,29 @@ defmodule MoxTest do
       expect(CalcMock, :add, fn x, y -> x + y end)
       expect(SciCalcOnlyMock, :exponent, fn x, y -> x * y end)
 
-      message = ~r"expected CalcMock.add/2 to be invoked once but it was invoked 0 times"
-      assert_raise Mox.VerificationError, message, fn -> verify!(CalcMock) end
-      message = ~r"expected SciCalcOnlyMock.exponent/2 to be invoked once but it was invoked 0 times"
-      assert_raise Mox.VerificationError, message, fn -> verify!(SciCalcOnlyMock) end
+      error = assert_raise(Mox.VerificationError, fn -> verify!(CalcMock) end)
+      assert error.message =~ ~r"expected CalcMock.add/2 to be invoked once but it was invoked 0 times"
+      refute error.message =~ ~r"expected SciCalcOnlyMock.exponent/2"
+
+      error = assert_raise(Mox.VerificationError, fn -> verify!(SciCalcOnlyMock) end)
+      assert error.message =~ ~r"expected SciCalcOnlyMock.exponent/2 to be invoked once but it was invoked 0 times"
+      refute error.message =~ ~r"expected CalcMock.add/2"
 
       CalcMock.add(2, 3)
       verify!(CalcMock)
-      message = ~r"expected SciCalcOnlyMock.exponent/2 to be invoked once but it was invoked 0 times"
-      assert_raise Mox.VerificationError, message, fn -> verify!(SciCalcOnlyMock) end
+
+      error = assert_raise(Mox.VerificationError, fn -> verify!(SciCalcOnlyMock) end)
+      assert error.message =~ ~r"expected SciCalcOnlyMock.exponent/2 to be invoked once but it was invoked 0 times"
+      refute error.message =~ ~r"expected CalcMock.add/2"
 
       SciCalcOnlyMock.exponent(2, 3)
       verify!(CalcMock)
       verify!(SciCalcOnlyMock)
 
       expect(CalcMock, :add, fn x, y -> x + y end)
-      message = ~r"expected CalcMock.add/2 to be invoked 2 times but it was invoked once"
-      assert_raise Mox.VerificationError, message, fn -> verify!(CalcMock) end
+      error = assert_raise Mox.VerificationError, fn -> verify!(CalcMock) end
+      assert error.message =~ ~r"expected CalcMock.add/2 to be invoked 2 times but it was invoked once"
+      refute error.message =~ ~r"expected SciCalcOnlyMock.exponent/2"
       verify!(SciCalcOnlyMock)
     end
 
@@ -439,24 +445,32 @@ defmodule MoxTest do
       expect(CalcMock, :add, fn x, y -> x + y end)
       expect(SciCalcOnlyMock, :exponent, fn x, y -> x * y end)
 
-      message = ~r"expected CalcMock.add/2 to be invoked once but it was invoked 0 times"
-      assert_raise Mox.VerificationError, message, fn -> verify!(CalcMock) end
-      message = ~r"expected SciCalcOnlyMock.exponent/2 to be invoked once but it was invoked 0 times"
-      assert_raise Mox.VerificationError, message, fn -> verify!(SciCalcOnlyMock) end
+      error = assert_raise(Mox.VerificationError, fn -> verify!(CalcMock) end)
+      assert error.message =~ ~r"expected CalcMock.add/2 to be invoked once but it was invoked 0 times"
+      refute error.message =~ ~r"expected SciCalcOnlyMock.exponent/2"
+
+      error = assert_raise(Mox.VerificationError, fn -> verify!(SciCalcOnlyMock) end)
+      assert error.message =~ ~r"expected SciCalcOnlyMock.exponent/2 to be invoked once but it was invoked 0 times"
+      refute error.message =~ ~r"expected CalcMock.add/2"
 
       Task.async(fn -> CalcMock.add(2, 3) end)
       |> Task.await()
       verify!(CalcMock)
-      message = ~r"expected SciCalcOnlyMock.exponent/2 to be invoked once but it was invoked 0 times"
-      assert_raise Mox.VerificationError, message, fn -> verify!(SciCalcOnlyMock) end
+      
+      error = assert_raise(Mox.VerificationError, fn -> verify!(SciCalcOnlyMock) end)
+      assert error.message =~ ~r"expected SciCalcOnlyMock.exponent/2 to be invoked once but it was invoked 0 times"
+      refute error.message =~ ~r"expected CalcMock.add/2"
 
       SciCalcOnlyMock.exponent(2, 3)
       verify!(CalcMock)
       verify!(SciCalcOnlyMock)
 
       expect(CalcMock, :add, fn x, y -> x + y end)
-      message = ~r"expected CalcMock.add/2 to be invoked 2 times but it was invoked once"
-      assert_raise Mox.VerificationError, message, &verify!/0
+      
+      error = assert_raise(Mox.VerificationError, &verify!/0)
+      assert error.message =~ ~r"expected CalcMock.add/2 to be invoked 2 times but it was invoked once"
+      refute error.message =~ ~r"expected SciCalcOnlyMock.exponent/2"
+
       verify!(SciCalcOnlyMock)
     end
 

--- a/test/mox_test.exs
+++ b/test/mox_test.exs
@@ -353,38 +353,23 @@ defmodule MoxTest do
       expect(CalcMock, :add, fn x, y -> x + y end)
       expect(SciCalcOnlyMock, :exponent, fn x, y -> x * y end)
 
-      assert_raise(Mox.VerificationError, &verify!/0)
-      try do
-        verify!()
-      rescue
-        error in Mox.VerificationError ->
-          assert error.message =~ ~r"expected CalcMock.add/2 to be invoked once but it was invoked 0 times"
-          assert error.message =~ ~r"expected SciCalcOnlyMock.exponent/2 to be invoked once but it was invoked 0 times"
-      end
+      error = assert_raise(Mox.VerificationError, &verify!/0)
+      assert error.message =~ ~r"expected CalcMock.add/2 to be invoked once but it was invoked 0 times"
+      assert error.message =~ ~r"expected SciCalcOnlyMock.exponent/2 to be invoked once but it was invoked 0 times"
 
       CalcMock.add(2, 3)
-      assert_raise(Mox.VerificationError, &verify!/0)
-      try do
-        verify!()
-      rescue
-        error in Mox.VerificationError ->
-          refute error.message =~ ~r"expected CalcMock.add/2"
-          assert error.message =~ ~r"expected SciCalcOnlyMock.exponent/2 to be invoked once but it was invoked 0 times"
-      end
+      error = assert_raise(Mox.VerificationError, &verify!/0)
+      refute error.message =~ ~r"expected CalcMock.add/2"
+      assert error.message =~ ~r"expected SciCalcOnlyMock.exponent/2 to be invoked once but it was invoked 0 times"  
 
       SciCalcOnlyMock.exponent(2, 3)
       verify!()
 
       # Adding another expected call makes verification fail again
       expect(CalcMock, :add, fn x, y -> x + y end)
-      assert_raise(Mox.VerificationError, &verify!/0)
-      try do
-        verify!()
-      rescue
-        error in Mox.VerificationError ->
-          assert error.message =~ ~r"expected CalcMock.add/2 to be invoked 2 times but it was invoked once"
-          refute error.message =~ ~r"expected SciCalcOnlyMock.exponent/2"
-      end
+      error = assert_raise(Mox.VerificationError, &verify!/0)
+      assert error.message =~ ~r"expected CalcMock.add/2 to be invoked 2 times but it was invoked once"
+      refute error.message =~ ~r"expected SciCalcOnlyMock.exponent/2"
     end
 
     test "verifies all mocks for the current process in global mode" do
@@ -394,26 +379,16 @@ defmodule MoxTest do
       expect(CalcMock, :add, fn x, y -> x + y end)
       expect(SciCalcOnlyMock, :exponent, fn x, y -> x * y end)
 
-      assert_raise(Mox.VerificationError, &verify!/0)
-      try do
-        verify!()
-      rescue
-        error in Mox.VerificationError ->
-          assert error.message =~ ~r"expected CalcMock.add/2 to be invoked once but it was invoked 0 times"
-          assert error.message =~ ~r"expected SciCalcOnlyMock.exponent/2 to be invoked once but it was invoked 0 times"
-      end
+      error = assert_raise(Mox.VerificationError, &verify!/0)
+      assert error.message =~ ~r"expected CalcMock.add/2 to be invoked once but it was invoked 0 times"
+      assert error.message =~ ~r"expected SciCalcOnlyMock.exponent/2 to be invoked once but it was invoked 0 times"
 
       Task.async(fn -> SciCalcOnlyMock.exponent(2, 4) end)
       |> Task.await()
 
-      assert_raise(Mox.VerificationError, &verify!/0)
-      try do
-        verify!()
-      rescue
-        error in Mox.VerificationError ->
-          assert error.message =~ ~r"expected CalcMock.add/2 to be invoked once but it was invoked 0 times"
-          refute error.message =~ ~r"expected SciCalcOnlyMock.exponent/2"
-      end
+      error = assert_raise(Mox.VerificationError, &verify!/0)
+      assert error.message =~ ~r"expected CalcMock.add/2 to be invoked once but it was invoked 0 times"
+      refute error.message =~ ~r"expected SciCalcOnlyMock.exponent/2"
 
       Task.async(fn -> CalcMock.add(5, 6) end)
       |> Task.await()
@@ -421,14 +396,9 @@ defmodule MoxTest do
       verify!()
 
       expect(CalcMock, :add, fn x, y -> x + y end)
-      assert_raise(Mox.VerificationError, &verify!/0)
-      try do
-        verify!()
-      rescue
-        error in Mox.VerificationError ->
-          assert error.message =~ ~r"expected CalcMock.add/2 to be invoked 2 times but it was invoked once"
-          refute error.message =~ ~r"expected SciCalcOnlyMock.exponent/2"
-      end
+      error = assert_raise(Mox.VerificationError, &verify!/0)
+      assert error.message =~ ~r"expected CalcMock.add/2 to be invoked 2 times but it was invoked once"
+      refute error.message =~ ~r"expected SciCalcOnlyMock.exponent/2"
     end
   end
 

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -1,4 +1,5 @@
 Mox.defmock(CalcMock, for: Calculator)
+Mox.defmock(SciCalcOnlyMock, for: ScientificCalculator)
 Mox.defmock(SciCalcMock, for: [Calculator, ScientificCalculator])
 
 Mox.defmock(SciCalcMockWithoutOptional,


### PR DESCRIPTION
Before this PR the tests of `verify/0` didn't assert that failures would be reported across multiple Mocks and tests for `verify/1` didn't assert that failures in other Mocks would be ignored.