### PR TITLE
Add `Mox.deny/3`

### DIFF
--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -544,11 +544,11 @@ defmodule Mox do
   end
 
   @doc """
-  Ensures that `name` in `mock` with arity `arity` is not invoked.
+  Ensures that `name`/`arity` in `mock` is not invoked.
 
   When `deny/3` is invoked, any previously declared `stub` for the same `name` and arity will
   be removed. This ensures that `deny` will fail if the function is called. If a `stub/3` is
-  invoked **after** `deny/3` for the same `name` and arity, the stub will be used instead, so
+  invoked **after** `deny/3` for the same `name` and `arity`, the stub will be used instead, so
   `deny` will have no effect.
 
   ## Examples

--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -556,6 +556,7 @@ defmodule Mox do
   To expect `MockWeatherAPI.get_temp/1` to never be called:
 
       deny(MockWeatherAPI, :get_temp, 1)
+
   """
   @doc since: "1.2.0"
   @spec deny(mock, atom(), non_neg_integer()) :: mock when mock: t()

--- a/test/mox_test.exs
+++ b/test/mox_test.exs
@@ -345,6 +345,63 @@ defmodule MoxTest do
     end
   end
 
+  describe "deny/3" do
+    test "allows asserting that function is not called" do
+      CalcMock
+      |> deny(:add, 2)
+
+      msg = ~r"expected CalcMock.add/2 to be called 0 times but it has been called once"
+
+      assert_raise Mox.UnexpectedCallError, msg, fn ->
+        CalcMock.add(2, 3) == 5
+      end
+    end
+
+    test "raises if a non-mock is given" do
+      assert_raise ArgumentError, ~r"could not load module Unknown", fn ->
+        deny(Unknown, :add, 2)
+      end
+
+      assert_raise ArgumentError, ~r"module String is not a mock", fn ->
+        deny(String, :add, 2)
+      end
+    end
+
+    test "raises if function is not in behaviour" do
+      assert_raise ArgumentError, ~r"unknown function oops/2 for mock CalcMock", fn ->
+        deny(CalcMock, :oops, 2)
+      end
+
+      assert_raise ArgumentError, ~r"unknown function add/3 for mock CalcMock", fn ->
+        deny(CalcMock, :add, 3)
+      end
+    end
+
+    test "raises even when a stub is defined" do
+      stub(CalcMock, :add, fn _, _ -> :stub end)
+      deny(CalcMock, :add, 2)
+
+      assert_raise Mox.UnexpectedCallError, fn ->
+        CalcMock.add(2, 3)
+      end
+    end
+
+    test "raises if you try to add expectations from non global process" do
+      set_mox_global()
+
+      Task.async(fn ->
+        msg =
+          ~r"Only the process that set Mox to global can set expectations/stubs in global mode"
+
+        assert_raise ArgumentError, msg, fn ->
+          CalcMock
+          |> deny(:add, 2)
+        end
+      end)
+      |> Task.await()
+    end
+  end
+
   describe "verify!/0" do
     test "verifies all mocks for the current process in private mode" do
       set_mox_private()

--- a/test/mox_test.exs
+++ b/test/mox_test.exs
@@ -347,8 +347,7 @@ defmodule MoxTest do
 
   describe "deny/3" do
     test "allows asserting that function is not called" do
-      CalcMock
-      |> deny(:add, 2)
+      deny(CalcMock, :add, 2)
 
       msg = ~r"expected CalcMock.add/2 to be called 0 times but it has been called once"
 
@@ -394,8 +393,7 @@ defmodule MoxTest do
           ~r"Only the process that set Mox to global can set expectations/stubs in global mode"
 
         assert_raise ArgumentError, msg, fn ->
-          CalcMock
-          |> deny(:add, 2)
+          deny(CalcMock, :add, 2)
         end
       end)
       |> Task.await()


### PR DESCRIPTION
Allow denying a call to a mock with clearer intentions.
Closes #145.