### PR TITLE
Use :erlang.fun_info/2 instead of :erlang.fun_info/1

### DIFF
--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -657,7 +657,8 @@ defmodule Mox do
   end
 
   defp arity(code) do
-    :erlang.fun_info(code)[:arity]
+    {:arity, arity} = :erlang.fun_info(code, :arity)
+    arity
   end
 
   defp add_expectation!(mock, name, arity, value) do


### PR DESCRIPTION
`:erlang.fun_info/1` calls `:erlang.fun_info/2` for each function information, since we need only the arity we can just get this information directly for a small performance improvement.

```
❯ mix profile.fprof -e ":erlang.fun_info(&Function.identity/1, :arity)"
...

                                                                   CNT    ACC (ms)    OWN (ms)     
Total                                                                3       0.011       0.011     
:fprof.apply_start_stop/4                                            0       0.011       0.006     
anonymous fn/0 in :elixir_compiler_1.__FILE__/1                      1       0.005       0.004     
:erlang.fun_info/2                                                   1       0.001       0.001     
:undefined                                                           0       0.000       0.000     
:suspend                                                             1       0.000       0.000     

❯ mix profile.fprof -e ":erlang.fun_info(&Function.identity/1)"
...
                                                                   CNT    ACC (ms)    OWN (ms)     
Total                                                               24       0.043       0.043     
:fprof.apply_start_stop/4                                            0       0.043       0.006     
anonymous fn/0 in :elixir_compiler_1.__FILE__/1                      1       0.037       0.002     
:erlang.fun_info/1                                                   1       0.035       0.002     
:erlang.fun_info_1/3                                                11       0.033       0.023     
:erlang.fun_info/2                                                  10       0.010       0.010     
:undefined                                                           0       0.000       0.000     
:suspend                                                             1       0.000       0.000     
```