### PR TITLE
Fix verify_on_exit!/1 with nimble_ownership

### DIFF
--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -807,8 +807,7 @@ defmodule Mox do
   # Made public for testing.
   @doc false
   def verify_mock_or_all!(owner_pid, mock_or_all) do
-    all_expectations =
-      NimbleOwnership.get_owned(@this, owner_pid, _default = %{}, @timeout)
+    all_expectations = NimbleOwnership.get_owned(@this, owner_pid, _default = %{}, @timeout)
 
     pending =
       for {_mock, expected_funs} <- all_expectations,

--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -804,8 +804,11 @@ defmodule Mox do
     verify_mock_or_all!(self(), mock)
   end
 
-  defp verify_mock_or_all!(owner_pid, mock_or_all) do
-    all_expectations = NimbleOwnership.get_owned(@this, owner_pid, _default = %{}, @timeout)
+  # Made public for testing.
+  @doc false
+  def verify_mock_or_all!(owner_pid, mock_or_all) do
+    all_expectations =
+      NimbleOwnership.get_owned(@this, owner_pid, _default = %{}, @timeout)
 
     pending =
       for {_mock, expected_funs} <- all_expectations,

--- a/test/mox_test.exs
+++ b/test/mox_test.exs
@@ -640,6 +640,25 @@ defmodule MoxTest do
     end
   end
 
+  describe "verify_on_exit!/0 with errors" do
+    test "raises if the mocks are not called" do
+      pid = self()
+
+      # This replicates exactly what verify_on_exit/1 does, but it adds an assertion
+      # in there. There's no easy way to test that something gets raised in an on_exit
+      # callback.
+      ExUnit.Callbacks.on_exit(Mox, fn ->
+        assert_raise Mox.VerificationError, fn ->
+          verify_mock_or_all!(pid, :all)
+        end
+      end)
+
+      set_mox_private()
+
+      expect(CalcMock, :add, fn x, y -> x + y end)
+    end
+  end
+
   describe "stub/3" do
     test "allows repeated invocations" do
       in_all_modes(fn ->


### PR DESCRIPTION
There's no fix here, just the failing test for now. Will work on this soon.