### PR TITLE
fix stub_with/2 documentation

### DIFF
--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -610,7 +610,7 @@ defmodule Mox do
       end
 
       defmodule MyApp.StubWeatherAPI do
-        @behaviour WeatherAPI
+        @behaviour MyApp.WeatherAPI
         def temp(_loc), do: {:ok, 30}
         def humidity(_loc), do: {:ok, 60}
       end


### PR DESCRIPTION
when reading stub_with documentation, I noticed that the behaviour name in the example was  wrong:

```
defmodule MyApp.WeatherAPI do
  @callback temp(MyApp.LatLong.t()) :: {:ok, integer()}
  @callback humidity(MyApp.LatLong.t()) :: {:ok, integer()}
end

defmodule MyApp.StubWeatherAPI do
  @behaviour WeatherAPI
  def temp(_loc), do: {:ok, 30}
  def humidity(_loc), do: {:ok, 60}
end
```

so I added the missing part:
```
defmodule MyApp.StubWeatherAPI do
  @behaviour MyApp.WeatherAPI
  def temp(_loc), do: {:ok, 30}
  def humidity(_loc), do: {:ok, 60}
end
```