### PR TITLE
Optimize stub_with

### DIFF
--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -679,24 +679,29 @@ defmodule Mox do
       :ok ->
         :ok
 
-      {:error, {:currently_allowed, owner_pid}} ->
-        inspected = inspect(self())
-
-        raise ArgumentError, """
-        cannot add expectations/stubs to #{inspect(mock)} in the current process (#{inspected}) \
-        because the process has been allowed by #{inspect(owner_pid)}. \
-        You cannot define expectations/stubs in a process that has been allowed
-        """
-
-      {:error, {:not_shared_owner, global_pid}} ->
-        inspected = inspect(self())
-
-        raise ArgumentError, """
-        cannot add expectations/stubs to #{inspect(mock)} in the current process (#{inspected}) \
-        because Mox is in global mode and the global process is #{inspect(global_pid)}. \
-        Only the process that set Mox to global can set expectations/stubs in global mode
-        """
+      {:error, error} ->
+        raise ArgumentError, expectation_error_to_message(error, mock)
     end
+  end
+
+  defp expectation_error_to_message({:currently_allowed, owner_pid}, mock) do
+    inspected = inspect(self())
+
+    """
+    cannot add expectations/stubs to #{inspect(mock)} in the current process (#{inspected}) \
+    because the process has been allowed by #{inspect(owner_pid)}. \
+    You cannot define expectations/stubs in a process that has been allowed
+    """
+  end
+
+  defp expectation_error_to_message({:not_shared_owner, global_pid}, mock) do
+    inspected = inspect(self())
+
+    """
+    cannot add expectations/stubs to #{inspect(mock)} in the current process (#{inspected}) \
+    because Mox is in global mode and the global process is #{inspect(global_pid)}. \
+    Only the process that set Mox to global can set expectations/stubs in global mode
+    """
   end
 
   @doc """


### PR DESCRIPTION
Today `stub_with` calls `stub` for each functions that needs to be stubbed. This causes a significant overhead because some validations being done repeatedly, and sending multiple messages to store the state change. 

This PR updates `stub_with`  to avoid the issues above by storing a list with the stub key and expectation, and sending a single state update.
  
```
Name                   ips        average  deviation         median         99th %
bench (PR)         33.02 K       30.28 μs    ±25.30%       28.40 μs       65.52 μs
bench (main)        2.88 K      347.63 μs     ±9.18%      339.18 μs      453.12 μs

Comparison: 
bench (PR)         33.02 K
bench (main)        2.88 K - 11.48x slower +317.34 μs

Memory usage statistics:

Name                 average  deviation         median         99th %
bench (PR)           7.53 KB     ±0.15%        7.53 KB        7.53 KB
bench (main)        55.34 KB     ±0.10%       55.36 KB       55.36 KB

Comparison: 
bench (PR)           7.53 KB
bench (main)        55.34 KB - 7.35x memory usage +47.81 KB
```
```elixir
defmodule BenchBehaviour do
  @functions Enum.map(1..50, &:"get_v#{&1}")

  for function <- @functions do
    @callback unquote(function)() :: integer()
  end
end

defmodule BenchBehaviourImpl do
  @behaviour BenchBehaviour

  @functions Enum.map(1..50, &:"get_v#{&1}")

  for function <- @functions do
    @impl BenchBehaviour
    def unquote(function)() do
      unquote(function)
    end
  end
end

Mox.defmock(BenchBehaviourMock, for: BenchBehaviour)

Benchee.run(
  %{
    "bench" => fn ->
      Mox.stub_with(BenchBehaviourMock, BenchBehaviourImpl)
      NimbleOwnership.cleanup_owner({:global, Mox.Server}, self())
    end
  },
  time: 10,
  memory_time: 2
)
```