### PR TITLE
Remove redundant ownership check

### DIFF
--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -685,8 +685,11 @@ defmodule Mox do
       :ok ->
         :ok
 
+      {:error, error} when is_binary(error) ->
+        raise ArgumentError, error
+
       {:error, error} ->
-        raise ArgumentError, expectation_error_to_message(error, mock)
+        raise error
     end
   end
 
@@ -697,29 +700,12 @@ defmodule Mox do
       :ok ->
         :ok
 
+      {:error, error} when is_binary(error) ->
+        raise ArgumentError, error
+
       {:error, error} ->
-        raise ArgumentError, expectation_error_to_message(error, mock)
+        raise error
     end
-  end
-
-  defp expectation_error_to_message({:currently_allowed, owner_pid}, mock) do
-    inspected = inspect(self())
-
-    """
-    cannot add expectations/stubs to #{inspect(mock)} in the current process (#{inspected}) \
-    because the process has been allowed by #{inspect(owner_pid)}. \
-    You cannot define expectations/stubs in a process that has been allowed
-    """
-  end
-
-  defp expectation_error_to_message({:not_shared_owner, global_pid}, mock) do
-    inspected = inspect(self())
-
-    """
-    cannot add expectations/stubs to #{inspect(mock)} in the current process (#{inspected}) \
-    because Mox is in global mode and the global process is #{inspect(global_pid)}. \
-    Only the process that set Mox to global can set expectations/stubs in global mode
-    """
   end
 
   @doc """
@@ -948,13 +934,34 @@ defmodule Mox do
   end
 
   defp add_expectations(owner_pid, mock, key_expectation_list) do
-    case ensure_pid_can_add_expectation(owner_pid, mock) do
-      :ok ->
-        update_fun = &{:ok, init_or_merge_expectations(&1, key_expectation_list)}
-        :ok = get_and_update!(owner_pid, mock, update_fun)
+    update_fun = &{:ok, init_or_merge_expectations(&1, key_expectation_list)}
 
-      {:error, reason} ->
-        {:error, reason}
+    case get_and_update(owner_pid, mock, update_fun) do
+      {:ok, value} ->
+        value
+
+      {:error, %NimbleOwnership.Error{reason: {:already_allowed, _}}} ->
+        inspected = inspect(self())
+
+        {:error,
+         """
+         cannot add expectations/stubs to #{inspect(mock)} in the current process (#{inspected}) \
+         because the process has been allowed by #{inspect(owner_pid)}. \
+         You cannot define expectations/stubs in a process that has been allowed
+         """}
+
+      {:error, %NimbleOwnership.Error{reason: {:not_shared_owner, global_pid}}} ->
+        inspected = inspect(self())
+
+        {:error,
+         """
+         cannot add expectations/stubs to #{inspect(mock)} in the current process (#{inspected}) \
+         because Mox is in global mode and the global process is #{inspect(global_pid)}. \
+         Only the process that set Mox to global can set expectations/stubs in global mode
+         """}
+
+      {:error, error} ->
+        {:error, error}
     end
   end
 
@@ -981,17 +988,6 @@ defmodule Mox do
     end
   end
 
-  # Make sure that the owner_pid is either the owner or that the mock
-  # isn't owned yet.
-  defp ensure_pid_can_add_expectation(owner_pid, mock) do
-    case NimbleOwnership.fetch_owner(@this, [owner_pid], mock, @timeout) do
-      :error -> :ok
-      {tag, ^owner_pid} when tag in [:ok, :shared_owner] -> :ok
-      {:shared_owner, other_owner} -> {:error, {:not_shared_owner, other_owner}}
-      {:ok, other_owner} -> {:error, {:currently_allowed, other_owner}}
-    end
-  end
-
   defp fetch_owner_from_callers(caller_pids, mock) do
     # If the mock doesn't have an owner, it can't have expectations so we return :no_expectation.
     case NimbleOwnership.fetch_owner(@this, caller_pids, mock, @timeout) do
@@ -1000,8 +996,12 @@ defmodule Mox do
     end
   end
 
+  defp get_and_update(owner_pid, mock, update_fun) do
+    NimbleOwnership.get_and_update(@this, owner_pid, mock, update_fun, @timeout)
+  end
+
   defp get_and_update!(owner_pid, mock, update_fun) do
-    case NimbleOwnership.get_and_update(@this, owner_pid, mock, update_fun, @timeout) do
+    case get_and_update(owner_pid, mock, update_fun) do
       {:ok, return} -> return
       {:error, %NimbleOwnership.Error{} = error} -> raise error
     end


### PR DESCRIPTION
Today Mox does a ownership check before doing an update to store the expectations. This call can be avoided because NimbleOwnership already does this same check on `get_and_update`, and the error allows us to do the error mapping.

```
Name                   ips        average  deviation         median         99th %
bench (PR)         36.47 K       27.42 μs    ±34.15%       25.69 μs       61.83 μs
bench (main)       32.33 K       30.93 μs    ±34.77%       28.91 μs       66.20 μs

Comparison: 
bench (PR)         36.47 K
bench (main)       32.33 K - 1.13x slower +3.52 μs

Memory usage statistics:

Name                 average  deviation         median         99th %
bench (PR)           7.08 KB     ±0.02%        7.08 KB        7.08 KB
bench (main)         7.53 KB     ±0.15%        7.53 KB        7.53 KB
```
```elixir
defmodule BenchBehaviour do
  @functions Enum.map(1..50, &:"get_v#{&1}")

  for function <- @functions do
    @callback unquote(function)() :: integer()
  end
end

defmodule BenchBehaviourImpl do
  @behaviour BenchBehaviour

  @functions Enum.map(1..50, &:"get_v#{&1}")

  for function <- @functions do
    @impl BenchBehaviour
    def unquote(function)() do
      unquote(function)
    end
  end
end

Mox.defmock(BenchBehaviourMock, for: BenchBehaviour)

Benchee.run(
  %{
    "bench" => fn ->
      Mox.stub_with(BenchBehaviourMock, BenchBehaviourImpl)
      NimbleOwnership.cleanup_owner({:global, Mox.Server}, self())
    end
  },
  time: 10,
  memory_time: 2
)
```
