### PR TITLE
Clarify Mox.allow/3 usage with deferred functions

### DIFF
--- a/lib/mox.ex
+++ b/lib/mox.ex
@@ -760,6 +760,13 @@ defmodule Mox do
 
       allow(MyMock, self(), fn -> GenServer.whereis(Deferred) end)
 
+  This means that if the process isn’t started yet, you can pass a function
+  that resolves to the pid later. When the mock is invoked,
+  Mox will call this function. If it returns a pid, the call is allowed.
+  If it doesn’t, the expectation fails.
+
+  This is especially useful when testing a `GenServer` that calls the mock during `init/1`,
+  since the server’s pid is not available until after `start_link/1`.
   """
   @spec allow(mock, pid(), term()) :: mock when mock: t()
   def allow(mock, owner_pid, allowed_via) when is_atom(mock) and is_pid(owner_pid) do


### PR DESCRIPTION
When testing a process that calls a mock inside its init/1, I ran into an Mox.UnexpectedCallError because the process wasn’t yet started when defining Mox.allow/3.

The fix was to use a deferred function with Mox.allow/3, so that Mox resolves the process later when the mock is actually invoked.

This change updates the docs to clarify that deferred functions can be used in such cases.